### PR TITLE
Update to Palo entropy API

### DIFF
--- a/src/eaas.cpp
+++ b/src/eaas.cpp
@@ -22,11 +22,11 @@ std::vector<uint8_t> parseAndFlattenEntropy(const std::string& jsonResponse) {
 
     std::ostringstream concatenatedEntropy;
     for (const auto& item: doc["entropy"].GetArray()) {
-    if (!item.IsString()) {
-        throw std::runtime_error("Invalid entropy block");
+        if (!item.IsString()) {
+            throw std::runtime_error("Invalid entropy block");
+            }
+            concatenatedEntropy << base64_decode(item.GetString());
         }
-        concatenatedEntropy << base64_decode(item.GetString());
-    }
 
     std::string str = concatenatedEntropy.str();
 

--- a/src/qseed.cpp
+++ b/src/qseed.cpp
@@ -134,8 +134,7 @@ int main() {
     while(1) {
 
         // Download quantum random
-        uint32_t sizeInKibs = (commonConfig.qseedSize + 1023) / 1024;
-        std::vector<uint8_t> downloadedRandom = eaasClient.requestEntropy(sizeInKibs);
+        std::vector<uint8_t> downloadedRandom = eaasClient.requestEntropy(commonConfig.qseedSize);
 
         // Inject quantum random into HSM
         std::vector<uint8_t> random(downloadedRandom.begin(), downloadedRandom.begin() + commonConfig.qseedSize);


### PR DESCRIPTION
This application previously used Qrypt's legacy entropy API. This PR updates it to use the entropy API standard publish by the working group led by Palo Alto Networks.

This pull request updates the eaas.cpp and qseed.cpp files to enhance the entropy request process. Key changes include:

    Updates in eaas.cpp:
        Added new headers for JSON handling and string operations.
        Renamed and refactored the parseJsonResponse function to parseAndFlattenEntropy, improving JSON parsing and entropy extraction.
        Changed the HTTP request from GET to POST, updated the endpoint, and included a JSON body with block_size and block_count.
        Simplified the entropy decoding process.

    Updates in qseed.cpp:
        Adjusted the size parameter for the entropy request to use bytes instead of kilobytes.

